### PR TITLE
Instant UI update from submitted data and display last 5 rows (test)

### DIFF
--- a/backend/api/schema.py
+++ b/backend/api/schema.py
@@ -2,23 +2,27 @@ import graphene
 from graphene_django.types import DjangoObjectType
 from .models import Book, MyModel
 
-
 # Define BookType
+
+
 class BookType(DjangoObjectType):
     class Meta:
         model = Book
 
-
 # Define MyModelType
+
+
 class MyModelType(DjangoObjectType):
     class Meta:
         model = MyModel
 
-
 # Define Queries
+
+
 class Query(graphene.ObjectType):
     all_books = graphene.List(BookType)
     book_by_id = graphene.Field(BookType, id=graphene.Int())
+    last5_my_models = graphene.List(MyModelType)
 
     def resolve_all_books(self, info):
         return Book.objects.all()
@@ -26,8 +30,12 @@ class Query(graphene.ObjectType):
     def resolve_book_by_id(self, info, id):
         return Book.objects.get(pk=id)
 
+    def resolve_last5_my_models(self, info):
+        return MyModel.objects.order_by('-id')[:5]
 
 # Define CreateMyModel Mutation
+
+
 class CreateMyModel(graphene.Mutation):
     class Arguments:
         field1 = graphene.String(required=True)
@@ -41,8 +49,9 @@ class CreateMyModel(graphene.Mutation):
         mymodel.save()
         return CreateMyModel(mymodel=mymodel)
 
-
 # Define Mutations
+
+
 class Mutation(graphene.ObjectType):
     create_mymodel = CreateMyModel.Field()
 

--- a/backend/api/schema.py
+++ b/backend/api/schema.py
@@ -1,14 +1,21 @@
 import graphene
 from graphene_django.types import DjangoObjectType
-from .models import Book
+from .models import Book, MyModel
 
 
-# * Test Query
+# Define BookType
 class BookType(DjangoObjectType):
     class Meta:
         model = Book
 
 
+# Define MyModelType
+class MyModelType(DjangoObjectType):
+    class Meta:
+        model = MyModel
+
+
+# Define Queries
 class Query(graphene.ObjectType):
     all_books = graphene.List(BookType)
     book_by_id = graphene.Field(BookType, id=graphene.Int())
@@ -20,4 +27,25 @@ class Query(graphene.ObjectType):
         return Book.objects.get(pk=id)
 
 
-schema = graphene.Schema(query=Query)
+# Define CreateMyModel Mutation
+class CreateMyModel(graphene.Mutation):
+    class Arguments:
+        field1 = graphene.String(required=True)
+        field2 = graphene.String(required=True)
+        field3 = graphene.String(required=True)
+
+    mymodel = graphene.Field(MyModelType)
+
+    def mutate(self, info, field1, field2, field3):
+        mymodel = MyModel(field1=field1, field2=field2, field3=field3)
+        mymodel.save()
+        return CreateMyModel(mymodel=mymodel)
+
+
+# Define Mutations
+class Mutation(graphene.ObjectType):
+    create_mymodel = CreateMyModel.Field()
+
+
+# Define Schema
+schema = graphene.Schema(query=Query, mutation=Mutation)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from "react"
+// import { useEffect, useState } from "react"
+import { useEffect } from "react"
 import { useQuery } from "@apollo/client"
 import { GET_BOOKS } from "./queries"
 import FormComponent from "./components/FormComponent"
@@ -6,29 +7,34 @@ import "./App.css"
 
 function App() {
   // * From api_book db table
-  const { loading, error, data } = useQuery(GET_BOOKS)
+  const { loading, error, data, refetch } = useQuery(GET_BOOKS)
+  // * WebSocket/Daphne
   // * From api_mymodel db table
-  const [realTimeData, setRealTimeData] = useState([])
+  // const [realTimeData, setRealTimeData] = useState([])
 
+  // useEffect(() => {
+  //   // WebSocket Connection: The useEffect hook establishes a WebSocket connection when the component mounts and closes it when the component unmounts.
+  //   const socket = new WebSocket(
+  //     "ws://" + window.location.hostname + ":8000/ws/api_mymodel/"
+  //   )
+  //   socket.onmessage = function (e) {
+  //     const newData = JSON.parse(e.data)
+  //     setRealTimeData((prevData) => [...prevData, newData])
+  //   }
+  //   socket.onclose = function (e) {
+  //     console.error("WebSocket closed unexpectedly")
+  //   }
+  //   return () => {
+  //     socket.close()
+  //   }
+  // }, [])
+
+  // * Refetch Data on Data Change:
+  // Added a useEffect hook that calls refetch() whenever data changes to ensure the latest data is fetched after a mutation.
+  // This ensures that your component will refetch the data from the GraphQL server whenever new data is added, without relying on WebSockets for real-time updates.
   useEffect(() => {
-    // WebSocket Connection: The useEffect hook establishes a WebSocket connection when the component mounts and closes it when the component unmounts.
-    const socket = new WebSocket(
-      "ws://" + window.location.hostname + ":8000/ws/api_mymodel/"
-    )
-
-    socket.onmessage = function (e) {
-      const newData = JSON.parse(e.data)
-      setRealTimeData((prevData) => [...prevData, newData])
-    }
-
-    socket.onclose = function (e) {
-      console.error("WebSocket closed unexpectedly")
-    }
-
-    return () => {
-      socket.close()
-    }
-  }, [])
+    refetch()
+  }, [data])
 
   if (loading) return <p>Loading...</p>
   if (error) return <p>Error :(</p>
@@ -47,7 +53,7 @@ function App() {
           </li>
         ))}
       </ul>
-      <h2>Daphne Websocket Server for real-time updates (not using GraphQL)</h2>
+      {/* <h2>Daphne Websocket Server for real-time updates (not using GraphQL)</h2>
       <ul>
         {realTimeData.map((item, index) => (
           <li key={index}>
@@ -57,7 +63,7 @@ function App() {
             <p>Field3: {item.field3}</p>
           </li>
         ))}
-      </ul>
+      </ul> */}
     </div>
   )
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,13 @@ function App() {
   const [getLast5MyModels, { loading: loadingLast5, data: last5Data }] =
     useLazyQuery(GET_LAST_5_MYMODELS)
 
+  // * Refetch Data on Data Change:
+  // Added a useEffect hook that calls refetch() whenever data changes to ensure the latest data is fetched after a mutation.
+  // This ensures that your component will refetch the data from the GraphQL server whenever new data is added, without relying on WebSockets for real-time updates.
+  useEffect(() => {
+    refetch()
+  }, [data])
+
   // Websocket for real-time updates from api_mymodel db table using Daphne server
   // * From api_mymodel db table
   // const [realTimeData, setRealTimeData] = useState([])
@@ -30,13 +37,6 @@ function App() {
   //     socket.close()
   //   }
   // }, [])
-
-  // * Refetch Data on Data Change:
-  // Added a useEffect hook that calls refetch() whenever data changes to ensure the latest data is fetched after a mutation.
-  // This ensures that your component will refetch the data from the GraphQL server whenever new data is added, without relying on WebSockets for real-time updates.
-  useEffect(() => {
-    refetch()
-  }, [data])
 
   if (loading) return <p>Loading...</p>
   if (error) return <p>Error :(</p>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,33 +1,15 @@
-// import { useEffect, useState } from "react"
-import { useEffect } from "react"
-import { useQuery } from "@apollo/client"
-import { GET_BOOKS } from "./queries"
+import { useEffect, useState } from "react"
+import { useQuery, useLazyQuery } from "@apollo/client"
+import { GET_BOOKS, GET_LAST_5_MYMODELS } from "./queries"
 import FormComponent from "./components/FormComponent"
 import "./App.css"
 
 function App() {
   // * From api_book db table
   const { loading, error, data, refetch } = useQuery(GET_BOOKS)
-  // * WebSocket/Daphne
-  // * From api_mymodel db table
-  // const [realTimeData, setRealTimeData] = useState([])
-
-  // useEffect(() => {
-  //   // WebSocket Connection: The useEffect hook establishes a WebSocket connection when the component mounts and closes it when the component unmounts.
-  //   const socket = new WebSocket(
-  //     "ws://" + window.location.hostname + ":8000/ws/api_mymodel/"
-  //   )
-  //   socket.onmessage = function (e) {
-  //     const newData = JSON.parse(e.data)
-  //     setRealTimeData((prevData) => [...prevData, newData])
-  //   }
-  //   socket.onclose = function (e) {
-  //     console.error("WebSocket closed unexpectedly")
-  //   }
-  //   return () => {
-  //     socket.close()
-  //   }
-  // }, [])
+  // Get last 5 models (last 5 rows) from api_mymodel db table
+  const [getLast5MyModels, { loading: loadingLast5, data: last5Data }] =
+    useLazyQuery(GET_LAST_5_MYMODELS)
 
   // * Refetch Data on Data Change:
   // Added a useEffect hook that calls refetch() whenever data changes to ensure the latest data is fetched after a mutation.
@@ -53,19 +35,111 @@ function App() {
           </li>
         ))}
       </ul>
-      {/* <h2>Daphne Websocket Server for real-time updates (not using GraphQL)</h2>
-      <ul>
-        {realTimeData.map((item, index) => (
-          <li key={index}>
-            <h2>Table Row</h2>
-            <p>Field1: {item.field1}</p>
-            <p>Field2: {item.field2}</p>
-            <p>Field3: {item.field3}</p>
-          </li>
-        ))}
-      </ul> */}
+      <button onClick={() => getLast5MyModels()}>Show Last 5 Entries</button>
+      {loadingLast5 && <p>Loading last 5 entries...</p>}
+      {last5Data && (
+        <ul>
+          {last5Data.last5MyModels.map((item, index) => (
+            <li key={index}>
+              <h2>Table Row</h2>
+              <p>Field1: {item.field1}</p>
+              <p>Field2: {item.field2}</p>
+              <p>Field3: {item.field3}</p>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   )
 }
 
 export default App
+// ******************************************************************
+// // import { useEffect, useState } from "react"
+// import { useEffect, useState } from "react"
+// import { useQuery, useLazyQuery } from "@apollo/client"
+// import { GET_BOOKS, GET_LAST_5_MYMODELS } from "./queries"
+// import FormComponent from "./components/FormComponent"
+// import "./App.css"
+
+// function App() {
+//   // * From api_book db table
+//   const { loading, error, data, refetch } = useQuery(GET_BOOKS)
+
+//   const [getLast5MyModels, { loading: loadingLast5, data: last5Data }]
+
+//   // * WebSocket/Daphne
+//   // * From api_mymodel db table
+//   // const [realTimeData, setRealTimeData] = useState([])
+
+//   // useEffect(() => {
+//   //   // WebSocket Connection: The useEffect hook establishes a WebSocket connection when the component mounts and closes it when the component unmounts.
+//   //   const socket = new WebSocket(
+//   //     "ws://" + window.location.hostname + ":8000/ws/api_mymodel/"
+//   //   )
+//   //   socket.onmessage = function (e) {
+//   //     const newData = JSON.parse(e.data)
+//   //     setRealTimeData((prevData) => [...prevData, newData])
+//   //   }
+//   //   socket.onclose = function (e) {
+//   //     console.error("WebSocket closed unexpectedly")
+//   //   }
+//   //   return () => {
+//   //     socket.close()
+//   //   }
+//   // }, [])
+
+//   // * Refetch Data on Data Change:
+//   // Added a useEffect hook that calls refetch() whenever data changes to ensure the latest data is fetched after a mutation.
+//   // This ensures that your component will refetch the data from the GraphQL server whenever new data is added, without relying on WebSockets for real-time updates.
+//   useEffect(() => {
+//     refetch()
+//   }, [data])
+
+//   if (loading) return <p>Loading...</p>
+//   if (error) return <p>Error :(</p>
+
+//   return (
+//     <div>
+//       <h1>Books</h1>
+//       <FormComponent />
+//       <p>{data.book}</p>
+//       <ul>
+//         {data.allBooks.map((book, index) => (
+//           <li key={index}>
+//             <h2>{book.title}</h2>
+//             <p>Author: {book.author}</p>
+//             <p>Published Date: {book.publishedDate}</p>
+//           </li>
+//         ))}
+//       </ul>
+//       <button onClick={() => getLast5MyModels()}>Show Last 5 Entries</button>
+//       {loadingLast5 && <p>Loading last 5 entries...</p>}
+//       {last5Data && (
+//         <ul>
+//           {last5Data.last5MyModels.map((item, index) => (
+//             <li key={index}>
+//               <h2>Table Row</h2>
+//               <p>Field1: {item.field1}</p>
+//               <p>Field2: {item.field2}</p>
+//               <p>Field3: {item.field3}</p>
+//             </li>
+//           ))}
+//         </ul>
+//       )}
+//       {/* <h2>Daphne Websocket Server for real-time updates (not using GraphQL)</h2>
+//       <ul>
+//         {realTimeData.map((item, index) => (
+//           <li key={index}>
+//             <h2>Table Row</h2>
+//             <p>Field1: {item.field1}</p>
+//             <p>Field2: {item.field2}</p>
+//             <p>Field3: {item.field3}</p>
+//           </li>
+//         ))}
+//       </ul> */}
+//     </div>
+//   )
+// }
+
+// export default App

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -68,98 +68,21 @@ function App() {
             </li>
           ))}
         </ul>
+        // * Websocket for real-time updates from api_mymodel db table using Daphne server
+        // <h2>Daphne Websocket Server for real-time updates (not using GraphQL)</h2>
+        // <ul>
+        //   {realTimeData.map((item, index) => (
+        //     <li key={index}>
+        //       <h2>Table Row</h2>
+        //       <p>Field1: {item.field1}</p>
+        //       <p>Field2: {item.field2}</p>
+        //       <p>Field3: {item.field3}</p>
+        //     </li>
+        //   ))}
+        // </ul>
       )}
     </div>
   )
 }
 
 export default App
-// ******************************************************************
-// // import { useEffect, useState } from "react"
-// import { useEffect, useState } from "react"
-// import { useQuery, useLazyQuery } from "@apollo/client"
-// import { GET_BOOKS, GET_LAST_5_MYMODELS } from "./queries"
-// import FormComponent from "./components/FormComponent"
-// import "./App.css"
-
-// function App() {
-//   // * From api_book db table
-//   const { loading, error, data, refetch } = useQuery(GET_BOOKS)
-
-//   const [getLast5MyModels, { loading: loadingLast5, data: last5Data }]
-
-//   // * WebSocket/Daphne
-//   // * From api_mymodel db table
-//   // const [realTimeData, setRealTimeData] = useState([])
-
-//   // useEffect(() => {
-//   //   // WebSocket Connection: The useEffect hook establishes a WebSocket connection when the component mounts and closes it when the component unmounts.
-//   //   const socket = new WebSocket(
-//   //     "ws://" + window.location.hostname + ":8000/ws/api_mymodel/"
-//   //   )
-//   //   socket.onmessage = function (e) {
-//   //     const newData = JSON.parse(e.data)
-//   //     setRealTimeData((prevData) => [...prevData, newData])
-//   //   }
-//   //   socket.onclose = function (e) {
-//   //     console.error("WebSocket closed unexpectedly")
-//   //   }
-//   //   return () => {
-//   //     socket.close()
-//   //   }
-//   // }, [])
-
-//   // * Refetch Data on Data Change:
-//   // Added a useEffect hook that calls refetch() whenever data changes to ensure the latest data is fetched after a mutation.
-//   // This ensures that your component will refetch the data from the GraphQL server whenever new data is added, without relying on WebSockets for real-time updates.
-//   useEffect(() => {
-//     refetch()
-//   }, [data])
-
-//   if (loading) return <p>Loading...</p>
-//   if (error) return <p>Error :(</p>
-
-//   return (
-//     <div>
-//       <h1>Books</h1>
-//       <FormComponent />
-//       <p>{data.book}</p>
-//       <ul>
-//         {data.allBooks.map((book, index) => (
-//           <li key={index}>
-//             <h2>{book.title}</h2>
-//             <p>Author: {book.author}</p>
-//             <p>Published Date: {book.publishedDate}</p>
-//           </li>
-//         ))}
-//       </ul>
-//       <button onClick={() => getLast5MyModels()}>Show Last 5 Entries</button>
-//       {loadingLast5 && <p>Loading last 5 entries...</p>}
-//       {last5Data && (
-//         <ul>
-//           {last5Data.last5MyModels.map((item, index) => (
-//             <li key={index}>
-//               <h2>Table Row</h2>
-//               <p>Field1: {item.field1}</p>
-//               <p>Field2: {item.field2}</p>
-//               <p>Field3: {item.field3}</p>
-//             </li>
-//           ))}
-//         </ul>
-//       )}
-//       {/* <h2>Daphne Websocket Server for real-time updates (not using GraphQL)</h2>
-//       <ul>
-//         {realTimeData.map((item, index) => (
-//           <li key={index}>
-//             <h2>Table Row</h2>
-//             <p>Field1: {item.field1}</p>
-//             <p>Field2: {item.field2}</p>
-//             <p>Field3: {item.field3}</p>
-//           </li>
-//         ))}
-//       </ul> */}
-//     </div>
-//   )
-// }
-
-// export default App

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,26 @@ function App() {
   const [getLast5MyModels, { loading: loadingLast5, data: last5Data }] =
     useLazyQuery(GET_LAST_5_MYMODELS)
 
+  // Websocket for real-time updates from api_mymodel db table using Daphne server
+  // * From api_mymodel db table
+  // const [realTimeData, setRealTimeData] = useState([])
+  // useEffect(() => {
+  //   // WebSocket Connection: The useEffect hook establishes a WebSocket connection when the component mounts and closes it when the component unmounts.
+  //   const socket = new WebSocket(
+  //     "ws://" + window.location.hostname + ":8000/ws/api_mymodel/"
+  //   )
+  //   socket.onmessage = function (e) {
+  //     const newData = JSON.parse(e.data)
+  //     setRealTimeData((prevData) => [...prevData, newData])
+  //   }
+  //   socket.onclose = function (e) {
+  //     console.error("WebSocket closed unexpectedly")
+  //   }
+  //   return () => {
+  //     socket.close()
+  //   }
+  // }, [])
+
   // * Refetch Data on Data Change:
   // Added a useEffect hook that calls refetch() whenever data changes to ensure the latest data is fetched after a mutation.
   // This ensures that your component will refetch the data from the GraphQL server whenever new data is added, without relying on WebSockets for real-time updates.

--- a/frontend/src/components/FormComponent.jsx
+++ b/frontend/src/components/FormComponent.jsx
@@ -1,10 +1,16 @@
 import { useState } from "react"
+import { useMutation } from "@apollo/client"
+import { ADD_MYMODEL, GET_BOOKS } from "../queries"
 
 const FormComponent = () => {
   const [formData, setFormData] = useState({
     field1: "",
     field2: "",
     field3: "",
+  })
+
+  const [addMyModel] = useMutation(ADD_MYMODEL, {
+    refetchQueries: [{ query: GET_BOOKS }],
   })
 
   const handleChange = (e) => {
@@ -15,22 +21,11 @@ const FormComponent = () => {
     })
   }
 
-  // ! Submit form data to backend from here
   const handleSubmit = async (e) => {
     e.preventDefault()
     try {
-      const response = await fetch("http://localhost:8000/api/submit", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(formData),
-      })
-      if (response.ok) {
-        console.log("Data submitted successfully")
-      } else {
-        console.error("Error submitting data")
-      }
+      await addMyModel({ variables: { ...formData } })
+      console.log("Data submitted successfully")
     } catch (error) {
       console.error("Error:", error)
     }

--- a/frontend/src/components/FormComponent.jsx
+++ b/frontend/src/components/FormComponent.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react"
 import { useMutation } from "@apollo/client"
-import { ADD_MYMODEL, GET_BOOKS } from "../queries"
+import { ADD_MYMODEL, GET_BOOKS, GET_LAST_5_MYMODELS } from "../queries"
 
 const FormComponent = () => {
   const [formData, setFormData] = useState({
@@ -10,7 +10,7 @@ const FormComponent = () => {
   })
 
   const [addMyModel] = useMutation(ADD_MYMODEL, {
-    refetchQueries: [{ query: GET_BOOKS }],
+    refetchQueries: [{ query: GET_BOOKS }, { query: GET_LAST_5_MYMODELS }],
   })
 
   const handleChange = (e) => {

--- a/frontend/src/queries.jsx
+++ b/frontend/src/queries.jsx
@@ -23,5 +23,16 @@ export const ADD_MYMODEL = gql`
   }
 `
 
+// * Get the last 5 rows from the database
+export const GET_LAST_5_MYMODELS = gql`
+  query GetLast5MyModels {
+    last5MyModels {
+      field1
+      field2
+      field3
+    }
+  }
+`
+
 // { gql } is a tagged template literal function provided by Apollo Client. It's used to parse GraphQL query strings into the abstract syntax tree (AST) that Apollo Client uses internally.
 // It allows you to write GraphQL queries directly in your JavaScript code.

--- a/frontend/src/queries.jsx
+++ b/frontend/src/queries.jsx
@@ -9,5 +9,19 @@ export const GET_BOOKS = gql`
     }
   }
 `
+
+// * Add a new mymodel to the database
+export const ADD_MYMODEL = gql`
+  mutation AddMyModel($field1: String!, $field2: String!, $field3: String!) {
+    createMymodel(field1: $field1, field2: $field2, field3: $field3) {
+      mymodel {
+        field1
+        field2
+        field3
+      }
+    }
+  }
+`
+
 // { gql } is a tagged template literal function provided by Apollo Client. It's used to parse GraphQL query strings into the abstract syntax tree (AST) that Apollo Client uses internally.
 // It allows you to write GraphQL queries directly in your JavaScript code.


### PR DESCRIPTION
- Revert code to exclusively use GraphQL for read/write database from UI
- Add a test to display last 5 rows from db which will work with newly added rows(models)
- Preserve Websocket code temporarily in case a use case is found